### PR TITLE
New issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/information-correction.yaml
+++ b/.github/ISSUE_TEMPLATE/information-correction.yaml
@@ -1,5 +1,6 @@
 name: Information Correction
 title: "[Info Correction]: "
+labels: ["bug"]
 description: Have incorrect/outdated information found on the docs corrected
 body:
   - type: markdown # only displayed to the user when filling out the form
@@ -10,7 +11,7 @@ body:
     attributes:
       label: Page name
       description: On which page is the problem found in? 
-      placeholder: Page name
+      placeholder: Enter page name here
     validations:
       required: true  # Form cannot be submitted unless this field is not blank
 

--- a/.github/ISSUE_TEMPLATE/question-clarification.yaml
+++ b/.github/ISSUE_TEMPLATE/question-clarification.yaml
@@ -1,0 +1,24 @@
+name: Question
+title: "[Question] "
+labels: ["question"]
+description: Ask a question about the documentation or the infomation on the documentation site
+body:
+  - type: markdown
+    attributes:
+      value: If you have a question about the documentation or infomation on the docs site, you can ask it here
+
+  - type: input
+    id: input
+    attributes:
+      label: Question
+      description: Ask your question here. More detailed information can be entered in the 'More information' box below.
+      placeholder: Type here to enter your question
+    validations:
+        required: true
+
+  - type: textarea
+    id: moreinfo
+    attributes:
+      label: More information (Optional)
+      description: You can type here to supply more detailed information to the question
+      placeholder: More detailed information, such as documentation for other plugins can be supplied here


### PR DESCRIPTION
Adds new issue templates for users to use when creating issues

Uses the new issue forms templates (https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) in order to ensure people enter data in the correct format and to make sure contributors get the correct information that is needed.

What these look like:

![image](https://user-images.githubusercontent.com/77434904/138781192-f194a5dd-7883-4f15-9ab6-937ae59b9798.png)

(this next screenshot comes from my fork)
![image](https://user-images.githubusercontent.com/77434904/138781241-dd653f3a-4548-41a9-b94b-d9e2b5e4d94a.png)
