### PR TITLE
various page changes, add chunky forge link, some more

### DIFF
--- a/docs/plugins_and_modifications/fabric-mods.md
+++ b/docs/plugins_and_modifications/fabric-mods.md
@@ -24,6 +24,8 @@ image: https://bloom.host/assets/images/logo.png
 # Installing Fabric mods on your server
 :::note
 This tutorial is for [Fabric](https://fabricmc.org) servers.
+
+For Forge servers, see the [Forge mod installation guide](forge-mods)
 :::
 
 You'll first need to find the mod that you wish to install. Downloads can be found on a variety of sites. Many mods can be found on [Modrinth](https://modrinth.com/mods) and [CurseForge](https://www.curseforge.com/minecraft/mc-mods/fabric). Make sure you trust the source of your downloads.

--- a/docs/plugins_and_modifications/fabric-setup.md
+++ b/docs/plugins_and_modifications/fabric-setup.md
@@ -3,7 +3,7 @@ id: fabric-setup
 title: Setting up Fabric
 slug: /fabric-setup
 hide_title: true
-hide_table_of_contents: true
+hide_table_of_contents: false
 sidebar_label: Setting up Fabric
 description: This guide will help you setup Fabric on your Minecraft server
 keywords:

--- a/docs/plugins_and_modifications/forge-mods.md
+++ b/docs/plugins_and_modifications/forge-mods.md
@@ -24,6 +24,8 @@ image: https://bloom.host/assets/images/logo.png
 # Installing Forge mods on your server
 :::note
 This tutorial is for [Forge](https://forums.minecraftforge.net/) servers.
+
+For Fabric servers, see the [Fabric mod installation guide](fabric-mods)
 :::
 
 You'll first need to find the mod you wish to install. Downloads can be found on a variety of sites. Many mods can be found on [CurseForge](https://www.curseforge.com/minecraft/mc-mods). Make sure you trust the source of your downloads.

--- a/docs/plugins_and_modifications/forge-setup.md
+++ b/docs/plugins_and_modifications/forge-setup.md
@@ -3,7 +3,7 @@ id: forge-setup
 title: Setting up Forge
 slug: /forge-setup
 hide_title: true
-hide_table_of_contents: true
+hide_table_of_contents: false
 sidebar_label: Setting up Forge
 description: This guide will help you setup Forge on your Minecraft server
 keywords:

--- a/docs/plugins_and_modifications/installing-plugins.md
+++ b/docs/plugins_and_modifications/installing-plugins.md
@@ -52,4 +52,4 @@ In case you can't seem to be able to install a plugin properly, be sure to do th
 1. **Check if the plugin has any dependencies**: In a lot of cases, plugins require other plugins to run. These should be listed on the website you got the plugin from. Simply download and install them the same way.
 2. **Check for additional settings**: In some cases plugins require additional configuration before they can be loaded properly.
 3. **Check for the plugin's version**: Even though most plugins after 1.13+ should be compatible with newer versions, this may not be the case with more sophisticated plugins. Be sure to check whether the plugin officially supports your Minecraft versions.
-4. **Check your startup logs**
+4. **Check your startup logs**: You should also check the startup logs as this can usually give you a hint to what’s wrong and causing a particular plugin to not start up properly. 

--- a/docs/plugins_and_modifications/installing-plugins.md
+++ b/docs/plugins_and_modifications/installing-plugins.md
@@ -3,7 +3,7 @@ id: installing-plugin
 title: Installing Plugins
 slug: /installing-plugins
 hide_title: true
-hide_table_of_contents: true
+hide_table_of_contents: false
 sidebar_label: Installing Spigot Plugins
 image: https://bloom.host/assets/images/logo.png
 ---

--- a/docs/plugins_and_modifications/multiplatform/chunky-multi.md
+++ b/docs/plugins_and_modifications/multiplatform/chunky-multi.md
@@ -34,6 +34,7 @@ For Bukkit/Spigot/Paper servers, check out the [Installing Bukkit/Spigot/Paper p
 
 For Fabric servers, check out the [Installing Fabric Mods](../fabric-mods.md) page.
 
+For Forge servers, check out the [Installing Forge Mods](../forge-mods.md) page.
 
 ## Usage
 
@@ -69,6 +70,8 @@ The table below can be used to estimate the file size of your world after you ge
 [Spigot Page](https://www.spigotmc.org/resources/chunky.81534/)  
 
 [CurseForge Page (Fabric version)](https://www.curseforge.com/minecraft/mc-mods/chunky-pregenerator/)
+
+[CurseForge Page (Forge version)](https://www.curseforge.com/minecraft/mc-mods/chunky-pregenerator-forge)
 
 [Wiki](https://github.com/pop4959/Chunky/wiki)
 

--- a/docs/plugins_and_modifications/multiplatform/luckperms.md
+++ b/docs/plugins_and_modifications/multiplatform/luckperms.md
@@ -58,7 +58,7 @@ Refer to the [LuckPerms wiki](https://luckperms.net/wiki/Installation) for infor
 
 To begin, simply run `/lp editor`. Once you have made your edits in the GUI, click save and run the command it gives you. If you need more help, consult the [LuckPerms wiki](https://luckperms.net/wiki/Home).  
 
-There are many commands that can be used to manage the permissions on your server(s) - see the [LuckPerms wiki](https://luckperms.net/wiki/Home) for more info.
+There are many commands that can be used to manage the permissions on your server(s) – see the [LuckPerms wiki](https://luckperms.net/wiki/Home) for more info.
 
 ## Info
 

--- a/docs/plugins_and_modifications/multiplatform/worldedit.md
+++ b/docs/plugins_and_modifications/multiplatform/worldedit.md
@@ -1,7 +1,7 @@
 ---
 id: worldedit
 title: WorldEdit
-slug: /plugins/worldedit
+slug: /multiplatform/worldedit
 hide_title: true
 hide_table_of_contents: false
 sidebar_label: WorldEdit
@@ -27,12 +27,14 @@ image: https://bloom.host/assets/images/logo.png
 WorldEdit is an in-game world editing plugin. You can select areas, fill them in with a block (or multiple types of blocks), save the area as a schematic, and more.  
 
 :::warning
-Pasting huge schematics or constructions with WorldEdit consumes a lot of server resources and as a result the server can lag and crash. We recommend you use [AsyncWorldEdit](https://www.spigotmc.org/resources/asyncworldedit.327/) for better performance. Keep in mind that you have to install both (AsyncWorldEdit and WorldEdit), and that AsyncWorldEdit is only compatible with specific WorldEdit versions. Check [AsyncWorldEdit Spigot page](https://www.spigotmc.org/resources/asyncworldedit.327/) for more information.
+Pasting huge schematics or constructions with WorldEdit consumes a lot of server resources and as a result the server can lag and crash. We recommend you use [AsyncWorldEdit](https://www.spigotmc.org/resources/asyncworldedit.327/) for better performance (Bukkit/Spigot/Paper only). Keep in mind that you have to install both (AsyncWorldEdit and WorldEdit), and that AsyncWorldEdit is only compatible with specific WorldEdit versions. Check [AsyncWorldEdit Spigot page](https://www.spigotmc.org/resources/asyncworldedit.327/) for more information.
 :::
 
 ### Setup
 
-Download the latest version for your Minecraft version (e.g. if your server is 1.16.2, download the latest one compatible with 1.16.2). Drop it in your plugins folder. Turn on or restart the server, and it should be working! If you need help installing plugins, check [How to install plugins](https://docs.bloom.host/installing-plugins).  
+Download the latest version for your Minecraft version (e.g. if your server is 1.16.2, download the latest one compatible with 1.16.2). Drop it in your plugins folder. Turn on or restart the server, and it should be working! If you need help installing plugins, check [How to install plugins](https://docs.bloom.host/installing-plugins).
+
+For other platforms (such as Forge or Fabric,) refer to [EngineHub’s guide on installing WorldEdit](https://worldedit.enginehub.org/en/latest/install/).
 
 ## Commands
 

--- a/docs/plugins_and_modifications/proxy-plugins.md
+++ b/docs/plugins_and_modifications/proxy-plugins.md
@@ -32,7 +32,7 @@ This guide is for BungeeCord/Velocity proxies. If you are looking for instructio
 
 ### Warning
 
-Make sure you trust the source of your plugin. Plugins have high-level access to your server. Do not attempt to use plugins from leak websites or similar. In some cases malicious plugins may even corrupt other plugins installed on your server or your world. 
+Make sure you trust the source of your plugin. Plugins have high-level access to your server. Do not attempt to use plugins from leak websites or similar. In some cases malicious plugins may even corrupt other plugins installed on your proxy. 
 
 ---
 

--- a/docs/plugins_and_modifications/proxy-plugins.md
+++ b/docs/plugins_and_modifications/proxy-plugins.md
@@ -3,7 +3,7 @@ id: install-proxy-plugin
 title: Installing Proxy Plugins (BungeeCord/Velocity)
 slug: /installing-proxy-plugins
 hide_title: true
-hide_table_of_contents: true
+hide_table_of_contents: false
 sidebar_label: Proxy (BungeeCord/Velocity) Plugins
 image: https://bloom.host/assets/images/logo.png
 ---

--- a/docs/running_a_server/waterfall.md
+++ b/docs/running_a_server/waterfall.md
@@ -122,7 +122,7 @@ You need to have 3 servers in total to be able to use a proxy server. 1 proxy se
 We need to add the backend servers to under the servers menu and the priorities list in the `config.yml` file.
 
 If for example, one of your backend servers is a survival server, you'll need to add this under your server section:
-```
+```yaml
 survival:
     motd: '&1Survival Server'
     address: <survival serverip>:port
@@ -132,7 +132,7 @@ survival:
 Afterwards you'll need to add the survival server to under priorities.
 
 When you're done with adding backend servers it might look like this:
-```
+```yaml
 connection_throttle: 4000
 connection_throttle_limit: 3
 timeout: 30000

--- a/netlify.toml
+++ b/netlify.toml
@@ -47,4 +47,8 @@
 [[redirects]] # AdvancedBan page
   from = "/plugins/advancedban"
   to = "/multiplatform/advancedban"
+
+[[redirects]] # WorldEdit page
+  from = "/plugins/worldedit"
+  to = "/multiplatform/worldedit"
 #############

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
 
 ############# 
 # These redirects were added when the multi-platform category for plugins and mods was added.
-# Some existing plugin/mod pages were moved (and in some cases, merged) from the platform-specific folder into the mult-platform folder.
+# Some existing plugin/mod pages were moved (and in some cases, merged) from the platform-specific folder into the multi-platform folder.
 # These redirect rules are to allow old links to continue to work as they get redirected to the new locations.
 
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -71,7 +71,7 @@ module.exports = {
             collapsed: true,
             items: [
                 'running_a_server/1.17', // 1.17 update information
-                'running_a_server/jars',
+                'running_a_server/jars', // Explains the different server JAR file options
                 'running_a_server/optimization', // Server optimisation information
                 'running_a_server/domain',
                 'running_a_server/resourcepack',
@@ -136,7 +136,7 @@ module.exports = {
                     label: "Multi-platform plugins & mods",
                     items: [
                         'plugins_and_modifications/multiplatform/advancedban', // Bans and punishment manager (Bukkit/Spigot/Paper, BungeeCord)
-                        'plugins_and_modifications/multiplatform/chunky', // World pre-generation plugin (Bukkit, Fabric)
+                        'plugins_and_modifications/multiplatform/chunky', // World pre-generation plugin (Bukkit, Fabric, Forge)
                         'plugins_and_modifications/multiplatform/dynmap', // Dynamic web map of Minecraft worlds (Spigot/Paper, Forge, Fabric)
                         'plugins_and_modifications/multiplatform/litebans', // Bans and punishment manager (Spigot/Paper, BungeeCord)
                         'plugins_and_modifications/multiplatform/luckperms', // Permissions (Bukkit/Spigot/Paper, BungeeCord, Sponge, Fabric, Nukkit, Velocity)

--- a/sidebars.js
+++ b/sidebars.js
@@ -4,7 +4,7 @@ For example, to add a page which had a filename of 'chunky-multi' and a page ID 
 
 'plugins_and_modifications/multiplatform/chunky'
 
-'plugins_and_modifications/multplatform/' is the path to the file and '/chunky' is the page ID.
+'plugins_and_modifications/multiplatform/' is the path to the file and '/chunky' is the page ID.
 
 The page ID can be found at the top of each document (usually the second line) where it will say 'id: <pageid>' (<pageid> would be the page ID you put into `sidebars.js`) 
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -141,7 +141,8 @@ module.exports = {
                         'plugins_and_modifications/multiplatform/litebans', // Bans and punishment manager (Spigot/Paper, BungeeCord)
                         'plugins_and_modifications/multiplatform/luckperms', // Permissions (Bukkit/Spigot/Paper, BungeeCord, Sponge, Fabric, Nukkit, Velocity)
                         'plugins_and_modifications/multiplatform/plan', // Player Analytics, (Bukkit/Spigot/Paper, Sponge, Nukkit, Fabric)
-                        'plugins_and_modifications/multiplatform/simple-voice-chat' // Voice chat (Bukkit/Spigot/Paper, Forge, Fabric)
+                        'plugins_and_modifications/multiplatform/simple-voice-chat', // Voice chat (Bukkit/Spigot/Paper, Forge, Fabric)
+                        'plugins_and_modifications/multiplatform/worldedit' // World management (Bukkit, Forge, Fabric, Sponge)
                     ]
                 },
 
@@ -172,8 +173,7 @@ module.exports = {
                         'plugins_and_modifications/plugins/venturechat',
                         'plugins_and_modifications/plugins/viaversion',
                         'plugins_and_modifications/plugins/votifier',
-                        'plugins_and_modifications/plugins/vulcan',
-                        'plugins_and_modifications/plugins/worldedit'
+                        'plugins_and_modifications/plugins/vulcan'
                     ]
                 },
             ]

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,7 +29,7 @@ module.exports = {
 
         {
             type: 'doc',
-            id: "running_a_server/1.17",
+            id: "running_a_server/1.17", // 1.17 update information
         },
 
 
@@ -70,9 +70,9 @@ module.exports = {
             label: 'Running a Server',
             collapsed: true,
             items: [
-                'running_a_server/1.17',
+                'running_a_server/1.17', // 1.17 update information
                 'running_a_server/jars',
-                'running_a_server/optimization',
+                'running_a_server/optimization', // Server optimisation information
                 'running_a_server/domain',
                 'running_a_server/resourcepack',
                 'running_a_server/java-version',
@@ -80,9 +80,9 @@ module.exports = {
                 'running_a_server/timings',
                 'running_a_server/motd',
                 'running_a_server/world-reset',
-                'running_a_server/converting-worlds',
+                'running_a_server/converting-worlds', // Converting worlds used on Bukkit (and forks) servers to allow for use in singleplayer/other server software
                 'running_a_server/icon',
-                'running_a_server/waterfall',
+                'running_a_server/waterfall', // BungeeCord fork
                 'running_a_server/velocity',
                 'running_a_server/binarysearch' // Troubleshooting errors caused by plugins
             ],
@@ -127,7 +127,7 @@ module.exports = {
                     type: 'category',
                     label: "Fabric mods",
                     items: [ // Note: Chunky and LuckPerms pages were moved to multiplatform category
-                        'plugins_and_modifications/fabric_mods/performance-mods'
+                        'plugins_and_modifications/fabric_mods/performance-mods' // Mods intended to improve client/server performance
                     ]
                 },
 
@@ -150,8 +150,8 @@ module.exports = {
                     type: 'category',
                     label: "Plugins", // Bukkit/Spigot/Paper plugins
                     items: [ // Note: Chunky, LiteBans, LuckPerms and PLAN pages were moved to multiplatform category
-                        'plugins_and_modifications/plugins/advancedanticheat',
-                        'plugins_and_modifications/plugins/bungeeguard',
+                        'plugins_and_modifications/plugins/advancedanticheat', // anticheat
+                        'plugins_and_modifications/plugins/bungeeguard', // BungeeCord security (prevents UUID spoof exploit)
                         'plugins_and_modifications/plugins/citizens2',
                         'plugins_and_modifications/plugins/conditionalcommands',
                         'plugins_and_modifications/plugins/coreprotect',
@@ -159,7 +159,7 @@ module.exports = {
                         'plugins_and_modifications/plugins/discordsrv', //Discord <-> Minecraft bridge
                         'plugins_and_modifications/plugins/essentialsx',
                         'plugins_and_modifications/plugins/geysermc', // Minecraft Bedrock player bridge
-                        'plugins_and_modifications/plugins/geyseraddons',
+                        'plugins_and_modifications/plugins/geyseraddons', // GeyserMC addons
                         'plugins_and_modifications/plugins/griefprevention',
                         'plugins_and_modifications/plugins/milk',
                         'plugins_and_modifications/plugins/multiverse', //Bukkit multi-world manager
@@ -170,10 +170,10 @@ module.exports = {
                         'plugins_and_modifications/plugins/spark',
                         'plugins_and_modifications/plugins/tebex',
                         'plugins_and_modifications/plugins/vault',
-                        'plugins_and_modifications/plugins/venturechat',
+                        'plugins_and_modifications/plugins/venturechat', // Chat handler
                         'plugins_and_modifications/plugins/viaversion',
-                        'plugins_and_modifications/plugins/votifier',
-                        'plugins_and_modifications/plugins/vulcan'
+                        'plugins_and_modifications/plugins/votifier', // Minecraft server vote site listener
+                        'plugins_and_modifications/plugins/vulcan' // anticheat
                     ]
                 },
             ]


### PR DESCRIPTION
## `fabric-mods.md`, `forge-mods.md`
Add link to forge mod page (fabric mods page)
Add link to fabric mod page (forge mods page)

## `worldedit.md`
WorldEdit runs on several server platforms, small changes to page were made

## `sidebars.js`
Add comments in several more pages
Move the worldedit link as page was moved.

## `forge-setup.md`, `installing-plugins.md`, `proxy-plugins.md`
Unhide the table of contents

## `netlify.toml`
Update the file for worldedit page move

## `chunky-multi.md`
Update page to include link to Forge version.

## `waterfall.md`
Add YAML syntax highlighting to config example