### PR TITLE
Reflect GHS++ rename

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -156,8 +156,8 @@
                 "type": "PC"
         },
         {
-                "name": "GHS++",
-                "ip": "ghspp.minecraft.best",
+                "name": "Endercube",
+                "ip": "mc.endercube.net",
                 "type": "PC"
         },
         {


### PR DESCRIPTION
Change GHS++ to Endercube due to the server's rename