### PR TITLE
Change paper.yml to paper-global.yml in Velocity setup

### DIFF
--- a/docs/running_a_server/velocity.md
+++ b/docs/running_a_server/velocity.md
@@ -119,7 +119,7 @@ This section also applies to forks based upon Paper such as Purpur or Pufferfish
 
 First, you need to disable BungeeCord forwarding if you had it enabled beforehand. Make sure `settings.bungeecord` is set to `false` in your `spigot.yml`.
 
-In `paper.yml`, set `settings.velocity-support.enabled` to `true` and `settings.velocity-support.secret` to match the secret in your `velocity.toml`. You must also set `settings.velocity-support.online-mode` to the `online-mode` setting in your `velocity.toml`. Once you're done editing `paper.yml`, reboot your server.
+In `config/paper-global.yml`, set `settings.velocity-support.enabled` to `true` and `settings.velocity-support.secret` to match the secret in your `velocity.toml`. You must also set `settings.velocity-support.online-mode` to the `online-mode` setting in your `velocity.toml`. Once you're done editing `paper-global.yml`, reboot your server.
 
 ### Modern Forwarding for Fabric
 


### PR DESCRIPTION
Makes [the Velocity setup page](https://docs.bloom.host/velocity) up to date with Paper 1.19's config changes