### PR TITLE
add modrinth plugin pages

### DIFF
--- a/docs/plugins_and_modifications/multiplatform/chunky-multi.md
+++ b/docs/plugins_and_modifications/multiplatform/chunky-multi.md
@@ -71,6 +71,8 @@ The table below can be used to estimate the file size of your world after you ge
 
 [CurseForge Page (Forge version)](https://www.curseforge.com/minecraft/mc-mods/chunky-pregenerator-forge)
 
+[Modrinth Page](https://modrinth.com/mod/chunky)
+
 [GitHub](https://github.com/pop4959/Chunky)
 
 [Wiki](https://github.com/pop4959/Chunky/wiki)

--- a/docs/plugins_and_modifications/multiplatform/simple-voice-chat.md
+++ b/docs/plugins_and_modifications/multiplatform/simple-voice-chat.md
@@ -30,7 +30,7 @@ In order to run Simple Voice Chat on your server, you need one of the following 
 ### Fabric
 
 1. Download the latest version of the [Fabric API](https://www.curseforge.com/minecraft/mc-mods/fabric-api/files/all) for your Minecraft version
-2. Download the Fabric version of [Simple Voice Chat](https://www.curseforge.com/minecraft/mc-mods/simple-voice-chat/files/all?filter-status=1&filter-game-version=2020709689%3A7499)
+2. Download the Fabric version of [Simple Voice Chat](https://www.curseforge.com/minecraft/mc-mods/simple-voice-chat/files/all?filter-status=1&filter-game-version=2020709689%3A7499) ([Alternative download link](https://modrinth.com/mod/simple-voice-chat))
 3. Open the [file manager](/file-manager-controls) in your dashboard
 4. Open the **mods** folder or create it if it doesn't exist
 <div class="text--center"><img src={require('../../../static/imgs/plugins_and_modifications/simple_voice_chat/1.png').default} alt="console"/></div>
@@ -40,7 +40,7 @@ In order to run Simple Voice Chat on your server, you need one of the following 
 
 ### Forge
 
-1. Download the Forge version of [Simple Voice Chat](https://www.curseforge.com/minecraft/mc-mods/simple-voice-chat/files/all?filter-status=1&filter-game-version=2020709689%3A7498)
+1. Download the Forge version of [Simple Voice Chat](https://www.curseforge.com/minecraft/mc-mods/simple-voice-chat/files/all?filter-status=1&filter-game-version=2020709689%3A7498) ([Alternative download link](https://modrinth.com/mod/simple-voice-chat))
 3. Open the [file manager](/file-manager-controls) in your dashboard
 4. Open the **mods** folder or create it if it doesn't exist
 <div class="text--center"><img src={require('../../../static/imgs/plugins_and_modifications/simple_voice_chat/1.png').default} alt="console"/></div>
@@ -49,7 +49,7 @@ In order to run Simple Voice Chat on your server, you need one of the following 
 
 ### Bukkit/Spigot/Paper
 
-1. Download the Bukkit based version of [Simple Voice Chat](https://www.curseforge.com/minecraft/bukkit-plugins/simple-voice-chat/files/all)
+1. Download the Bukkit based version of [Simple Voice Chat](https://www.curseforge.com/minecraft/bukkit-plugins/simple-voice-chat/files/all) ([Alternative download link](https://modrinth.com/mod/simple-voice-chat))
 2. Download [ProtocolLib](https://www.spigotmc.org/resources/protocollib.1997/)
 3. Open the [file manager](/file-manager-controls) in your dashboard
 4. Open the **plugins** folder or create it if it doesn't exist

--- a/docs/plugins_and_modifications/plugins/discordsrv.md
+++ b/docs/plugins_and_modifications/plugins/discordsrv.md
@@ -56,6 +56,8 @@ Finally, start your server! DiscordSRV has been installed and you will see your 
 
 [DiscordSRV Spigot Page](https://www.spigotmc.org/resources/discordsrv.18494/)
 
+[DiscordSRV Modrinth Page](https://modrinth.com/mod/discordsrv)
+
 [DiscordSRV GitHub Page](https://github.com/DiscordSRV/DiscordSRV)
 
 [DiscordSRV Official Wiki](https://docs.discordsrv.com/)

--- a/docs/plugins_and_modifications/plugins/essentialsx.md
+++ b/docs/plugins_and_modifications/plugins/essentialsx.md
@@ -110,6 +110,8 @@ For example, warp signs can take your player to a warp you defined with `/setwar
 
 [Spigot Resource Page](https://www.spigotmc.org/resources/essentialsx.9089/)
 
+[Modrinth Resource Page](https://modrinth.com/mod/essentialsx)
+
 [EssentialsX command reference](https://essinfo.xeya.me/commands.html)
 
 [EssentialsX permissions reference](https://essinfo.xeya.me/permissions.html)

--- a/docs/plugins_and_modifications/plugins/prism.md
+++ b/docs/plugins_and_modifications/plugins/prism.md
@@ -58,7 +58,9 @@ Once you've done that, you need to restart the server in order for changes to ta
 
 ## Info
 
-[Spigot Page](https://www.spigotmc.org/resources/prism.75166/)  
+[Spigot Page](https://www.spigotmc.org/resources/prism.75166/)
+
+[Modrinth Page](https://modrinth.com/mod/prism)
 
 [Jenkins](https://jenkins.addstar.com.au/job/Prism-Bukkit%201.16/)  
 


### PR DESCRIPTION
Recently, modrinth started allowing bukkit/spigot/paper/purpur plugins to be uploaded to their site. Some plugins now have a modrinth page and this adds links to those pages to the wiki pages.