### PR TITLE
GeyserMC console joining instructions

### DIFF
--- a/docs/plugins_and_modifications/plugins/geysermc.md
+++ b/docs/plugins_and_modifications/plugins/geysermc.md
@@ -38,9 +38,18 @@ GeyserMC requires your server to be on the latest version.
 Once you've installed it, create the allocation 19132 under the ports & proxies on the panel.  
 
 After that, just restart the server, and Bedrock players should now be able to connect to your Java server.  
-### Note: If you're also using Floodgate, you will have to set `auth-type` to `floodgate` in your Geyser config.yml
+
+:::important
+Players who are using the console version of Bedrock Minecraft must follow the instructions listed on [this page](https://wiki.geysermc.org/geyser/using-geyser-with-consoles/) as the console version does not allow joining of custom servers by default
+:::
+
+:::note
+If you're also using Floodgate, you will have to set `auth-type` to `floodgate` in your Geyser config.yml
+:::
 ## Info
 [Website](https://geysermc.org/)  
+
+[Console workaround instructions](https://wiki.geysermc.org/geyser/using-geyser-with-consoles/) (consoles cannot connect to custom servers by default; these instructions are to work around this)
 
 [Jenkins](https://ci.nukkitx.com/job/GeyserMC/job/Geyser/job/master/)  
 


### PR DESCRIPTION
By default, console versions of bedrock minecraft dont allow connections to custom-defined servers. This adds the workaround instructions as defined by the geysermc team