### PR TITLE
Add cyclic dependencies info

### DIFF
--- a/docs/plugins_and_modifications/installing-plugins.md
+++ b/docs/plugins_and_modifications/installing-plugins.md
@@ -45,6 +45,14 @@ Once the server is online, type `plugins` in your console. If you are able to se
 
 ---
 
+:::important
+
+Starting with Paper 1.19.3 build 405, changes made to the plugin loader means that setups with cyclic plugin dependencies (where plugin loading causes a loading loop which will cycle back to the original plugin) will no longer function. A server with plugin dependency loops will not load and will be shut down with an error.
+
+See the [Paper help page](https://docs.papermc.io/paper/reference/paper-plugins#cyclic-plugin-loading) for information on how to resolve the issue.
+
+:::
+
 ### What To Do If A Plugin Doesn't Load
 
 In case you can't seem to be able to install a plugin properly, be sure to do these steps before asking for help.

--- a/docs/running_a_server/1.19.md
+++ b/docs/running_a_server/1.19.md
@@ -29,6 +29,14 @@ A new version of the game with loads of new content also means potential new exp
 - Moreover, if you aren't utilizing our [completely free and automatic backup feature](../using_the_panel/backups.md), we would highly suggest you set that up before updating.
 - Once you update to 1.19 you can't go back to any previous version, unless you reset your worlds or restore a backup that was made when the server was on the previous version.
 
+:::important
+
+Starting with Paper 1.19.3 build 405, changes made to the plugin loader means that setups with cyclic plugin dependencies (where plugin loading causes a loading loop which will cycle back to the original plugin) will no longer function. A server with plugin dependency loops will not load and will be shut down with an error.
+
+See the [Paper help page](https://docs.papermc.io/paper/reference/paper-plugins#cyclic-plugin-loading) for information on how to resolve the issue.
+
+:::
+
 <div class="text--center">
 <img src={require('../../static/imgs/running_a_server/1.18/2.png').default} alt="logo" height="50%" width="50%"/>
 </div>

--- a/docs/running_a_server/1.19.md
+++ b/docs/running_a_server/1.19.md
@@ -35,6 +35,7 @@ Starting with Paper 1.19.3 build 405, changes made to the plugin loader means th
 
 See the [Paper help page](https://docs.papermc.io/paper/reference/paper-plugins#cyclic-plugin-loading) for information on how to resolve the issue.
 
+From Paper 1.19.3 build 425, the server will not stop on cyclic dependencies for Bukkit/Spigot plugins.
 :::
 
 <div class="text--center">


### PR DESCRIPTION
Recent changes to paper software prevents setups with cyclic dependencies from loading (https://docs.papermc.io/paper/reference/paper-plugins#cyclic-plugin-loading)