### PR TITLE
Add HibiscusMC to servers.json

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -164,5 +164,10 @@
                 "name": "Dotarch",
                 "ip": "play.dotarch.co",
                 "type": "PC"
+        },
+        {
+                "name": "HibiscusMC",
+                "ip": "play.hibiscusmc.com",
+                "type": "PC"
         }
 ]


### PR DESCRIPTION
This PR adds HibiscusMC, a bloom hosted server, to the servers.json file.