### PR TITLE
FIX : removed the How to update to 1.19 section from sidebar.js

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -35,12 +35,6 @@ module.exports = {
 
 
         {
-            type: 'doc',
-            id: "running_a_server/1.19", // 1.19 update information
-        },
-
-
-        {
             type: 'category',
             label: 'Getting Started',
             collapsed: false,


### PR DESCRIPTION
Fix: #277

Changes : Removed the "How to update to 1.19" section from sidebar.js