### PR TITLE
Add deprecation notice to `timings.md` 

### DIFF
--- a/docs/running_a_server/timings.md
+++ b/docs/running_a_server/timings.md
@@ -20,6 +20,13 @@ keywords:
 
 # **How to take a Timings Report**
 
+:::important
+The PaperMC team has decided to remove the Timings system and replace it with [Spark](https://docs.bloom.host/spark) in a future version. 
+Timings should be considered depricated and no longer be used.
+
+More information can be found [here](https://github.com/PaperMC/Paper/issues/8948)
+:::
+
 :::note
 As time has gone on, Timings has become a bit outdated, from the Bloom team we usually recommend using [Spark](https://docs.bloom.host/spark) instead.
 :::


### PR DESCRIPTION
PaperMC team intends to remove the Timings system and replace it with spark, this adds a message to the timings page stating this info