### PR TITLE
Replace velocitypowered forums with Hangar in Proxy plugin install page

### DIFF
--- a/docs/plugins_and_modifications/proxy-plugins.md
+++ b/docs/plugins_and_modifications/proxy-plugins.md
@@ -31,7 +31,7 @@ Make sure you trust the source of your plugin. Plugins have high-level access to
 
 ### Installing Plugins
 
-1. You'll first need to find the plugin you wish to install. Downloads can be found on a variety of sites. Common places are [spigotmc.org](https://spigotmc.org/resources) (look at the BungeeCord or Universal sections), [Velocity forums](https://forums.velocitypowered.com/c/plugins/5) or [Modrinth](https://modrinth.com/plugins) (under proxies filter select the proxy software you are using).
+1. You'll first need to find the plugin you wish to install. Downloads can be found on a variety of sites. Common places are [spigotmc.org](https://spigotmc.org/resources) (look at the BungeeCord or Universal sections), [Hangar](https://hangar.papermc.io/) (under platforms select which proxy software you are using) or [Modrinth](https://modrinth.com/plugins) (under proxies filter select the proxy software you are using).
 2. In any case, save the plugin to your local machine. Plugins can either be uploaded via the [web panel](https://mc.bloom.host) or through [SFTP](../using_the_panel/sftp.md). If you're uploading in bulk, go with the latter.
 3. In your server's root directory, locate the `plugins` folder, if it's not there then create a new directory named `plugins`. Navigate into this folder, and upload your plugin's file there!
 4. Most plugins will require you to restart your server before they take effect.


### PR DESCRIPTION
Velocity has been part of the PaperMC project for some time now, and the old velocitypowered forums has been shut down, replace this link with the one for hangar (includes plugins for both waterfall & velocity)