### PR TITLE
Add Waterfall end of support message to proxy plugin page

### DIFF
--- a/docs/plugins_and_modifications/proxy-plugins.md
+++ b/docs/plugins_and_modifications/proxy-plugins.md
@@ -10,8 +10,16 @@ sidebar_label: Proxy (BungeeCord/Velocity) Plugins
 This guide is for BungeeCord/Velocity proxies. If you are looking for instructions on how to install plugins on a Bukkit/Spigot/Paper server, please see [this guide](installing-plugins.md)
 :::
 
+:::caution Waterfall is End of Life
+Waterfall is considered end of life by the PaperMC team and is no longer maintained.
+The PaperMC group recommends that all users should migrate to [Velocity](velocity.md).
+
+More information is available at: https://forums.papermc.io/threads/announcing-the-end-of-life-of-waterfall.1088/
+:::
 
 ### The Basics
+
+
 
 > #### Requirements
 > 

--- a/sidebars.js
+++ b/sidebars.js
@@ -85,7 +85,7 @@ module.exports = {
                 'running_a_server/converting-worlds', // Converting worlds used on Bukkit (and forks) servers to allow for use in singleplayer/other server software
                 "plugins_and_modifications/fabric-setup",
                 "plugins_and_modifications/forge-setup",
-                'running_a_server/waterfall', // BungeeCord fork
+                'running_a_server/waterfall', // [Unsupported] BungeeCord fork 
                 'running_a_server/velocity',
                 'running_a_server/internal-servers',
                 'running_a_server/binarysearch', // Troubleshooting errors caused by plugins


### PR DESCRIPTION
Waterfall is now considered end of support, this adds a message to the proxy plugin install page to make users aware that it is end of life

We also should consider that plugin authors might choose to remove support for Bungeecord/Waterfall in future versions of plugins