### PR TITLE
Change FabricProxy-Lite link to modrinth

### DIFF
--- a/docs/plugins_and_modifications/plugins/venturechat.md
+++ b/docs/plugins_and_modifications/plugins/venturechat.md
@@ -20,6 +20,10 @@ VentureChat is the #1 Bukkit chat resource on Spigot which is a do-it-all chat p
 
 ## Usage
 
+:::important
+This plugin requires Java 17 or higher to work. The instructions on how to change the Java version used by your server are [here](/java-version)
+:::
+
 To use this plugin, [download](https://www.spigotmc.org/resources/venturechat.771/) the jar file you will use for installation. This plugin can be used on Bungeecord servers by placing it into the relative plugins folder too.
 
 Once you have downloaded the .jar file, upload it into your `plugins` folder then either start or restart the server. If you need assistance in installing plugins, check out [this guide](https://docs.bloom.host/installing-plugins).  
@@ -98,6 +102,6 @@ Once the above additions are added save the following files and run `/essentials
 
 [VentureChat Spigot](https://www.spigotmc.org/resources/venturechat.771/)  
 
-[BitBucket](https://bitbucket.org/Aust1n46/venturechat/)  
+[GitHub](https://github.com/Aust1n46/VentureChat)  
 
 [Wiki](https://www.spigotmc.org/wiki/venturechat-wiki/)

--- a/docs/plugins_and_modifications/plugins/venturechat.md
+++ b/docs/plugins_and_modifications/plugins/venturechat.md
@@ -20,10 +20,6 @@ VentureChat is the #1 Bukkit chat resource on Spigot which is a do-it-all chat p
 
 ## Usage
 
-:::important
-This plugin requires Java 17 or higher to work. The instructions on how to change the Java version used by your server are [here](/java-version)
-:::
-
 To use this plugin, [download](https://www.spigotmc.org/resources/venturechat.771/) the jar file you will use for installation. This plugin can be used on Bungeecord servers by placing it into the relative plugins folder too.
 
 Once you have downloaded the .jar file, upload it into your `plugins` folder then either start or restart the server. If you need assistance in installing plugins, check out [this guide](https://docs.bloom.host/installing-plugins).  
@@ -102,6 +98,6 @@ Once the above additions are added save the following files and run `/essentials
 
 [VentureChat Spigot](https://www.spigotmc.org/resources/venturechat.771/)  
 
-[GitHub](https://github.com/Aust1n46/VentureChat)  
+[BitBucket](https://bitbucket.org/Aust1n46/venturechat/)  
 
 [Wiki](https://www.spigotmc.org/wiki/venturechat-wiki/)

--- a/docs/running_a_server/velocity.md
+++ b/docs/running_a_server/velocity.md
@@ -137,7 +137,7 @@ Keep in mind that this steps have to be repeated for every Paper/Backend server 
 
 ### Modern Forwarding for Fabric
 
-A mod called [FabricProxy-Lite](https://www.curseforge.com/minecraft/mc-mods/fabricproxy-lite) allows you to use Velocity modern forwarding with a modded server using Fabric.
+A mod called [FabricProxy-Lite](https://modrinth.com/mod/fabricproxy-lite) allows you to use Velocity modern forwarding with a modded server using Fabric.
 
 ### BungeeGuard Forwarding for Spigot/Paper
 


### PR DESCRIPTION
The CurseForge page for FabricProxy-Lite mod is not being updated for the latest versions. This changes the download link to the modrinth page (this is shown on the curseforge page)