### PR TITLE
Plugin link maintenance

### DIFF
--- a/docs/plugins_and_modifications/plugins/advancedanticheat.md
+++ b/docs/plugins_and_modifications/plugins/advancedanticheat.md
@@ -24,6 +24,11 @@ It is recomended to use an alternative solution such as [Vulcan](vulcan.md).
 The following information is for archival purposes only.
 :::
 
+<details>
+<summary>
+VIEW LEGACY DOCUMENTATION
+</summary>
+
 ## What does the plugin do?
 
 AAC protects your server from gamebreaking hacks and unfair advantages such as:
@@ -99,3 +104,5 @@ Advanced Anti-Cheat is very user configurable, and as a result of this, is highl
 :::
 
 [Spigot Page](https://www.spigotmc.org/resources/aac-advanced-anti-cheat-hack-kill-aura-blocker.6442/)  
+
+</details>

--- a/docs/plugins_and_modifications/plugins/geysermc.md
+++ b/docs/plugins_and_modifications/plugins/geysermc.md
@@ -46,4 +46,4 @@ If you're also using Floodgate, you will have to set `auth-type` to `floodgate` 
 
 [Jenkins](https://ci.nukkitx.com/job/GeyserMC/job/Geyser/job/master/)  
 
-[Wiki](https://github.com/GeyserMC/Geyser/wiki)
+[Wiki](https://wiki.geysermc.org/)

--- a/docs/plugins_and_modifications/plugins/prism.md
+++ b/docs/plugins_and_modifications/plugins/prism.md
@@ -30,7 +30,7 @@ Before you get started, you need to have created a MySQL database. More info on 
 
 After that, go to the `Prism` folder, which can be found inside the `plugins` folder. From there, edit the `config.yml` file.  
 
-Go down to the `mysql` section and enter your database details. Change `useNonStandardSql: true` to `useNonStandardSql: false`.  
+Go down to the `datasource` section and under the `properties` sub-section enter your database details. Change `useNonStandardSql: true` to `useNonStandardSql: false`.  
 
 :::caution
 Do not copy the configuration below exactly, your login details for your own database will be different.

--- a/docs/plugins_and_modifications/plugins/prism.md
+++ b/docs/plugins_and_modifications/plugins/prism.md
@@ -26,7 +26,7 @@ Prism is a highly configurable, powerful, high-performance grief management (rol
 Before you get started, you need to have created a MySQL database. More info on that can be found [here](https://docs.bloom.host/databases).
 :::
 
-[Download the plugin](https://jenkins.addstar.com.au/job/Prism-Bukkit%201.16/) and upload the jar into your `plugins` folder. Restart or turn on the server. If you need help installing plugins, check out [this guide](https://docs.bloom.host/installing-plugins).  
+[Download the plugin](https://www.spigotmc.org/resources/prism.99397/) and upload the jar into your `plugins` folder. Restart or turn on the server. If you need help installing plugins, check out [this guide](https://docs.bloom.host/installing-plugins).  
 
 After that, go to the `Prism` folder, which can be found inside the `plugins` folder. From there, edit the `config.yml` file.  
 
@@ -37,11 +37,13 @@ Do not copy the configuration below exactly, your login details for your own dat
 :::
 
 ```YML
-  mysql:
+datasource:
+  type: mysql
+  properties:
     hostname: 135.181.0.179
     username: u69_Abbywontseethis
-    password: 'Impossible Password'
-    databaseName: s69_pogchamp
+    password: Impossible Password
+    databaseName: prism
     prefix: prism_
     port: '3306'
     useNonStandardSql: false
@@ -51,12 +53,10 @@ Once you've done that, you need to restart the server in order for changes to ta
 
 ## Info
 
-[Spigot Page](https://www.spigotmc.org/resources/prism.75166/)
+[Spigot Page](https://www.spigotmc.org/resources/prism.99397/)
 
-[Modrinth Page](https://modrinth.com/mod/prism)
+[Support](https://discord.gg/7FxZScH4EJ)
 
-[Jenkins](https://jenkins.addstar.com.au/job/Prism-Bukkit%201.16/)  
+[Wiki](https://prism-bukkit.readthedocs.io/en/latest/)  
 
-[Wiki](https://github.com/AddstarMC/Prism-Bukkit/wiki)  
-
-[GitHub](https://github.com/AddstarMC/Prism-Bukkit)
+[GitHub](https://github.com/prism/PrismRefracted)

--- a/docs/plugins_and_modifications/plugins/venturechat.md
+++ b/docs/plugins_and_modifications/plugins/venturechat.md
@@ -20,6 +20,10 @@ VentureChat is the #1 Bukkit chat resource on Spigot which is a do-it-all chat p
 
 ## Usage
 
+:::important
+This plugin requires Java 17 or higher to work. The instructions on how to change the Java version used by your server are [here](/java-version)
+:::
+
 To use this plugin, [download](https://www.spigotmc.org/resources/venturechat.771/) the jar file you will use for installation. This plugin can be used on Bungeecord servers by placing it into the relative plugins folder too.
 
 Once you have downloaded the .jar file, upload it into your `plugins` folder then either start or restart the server. If you need assistance in installing plugins, check out [this guide](https://docs.bloom.host/installing-plugins).  
@@ -98,6 +102,6 @@ Once the above additions are added save the following files and run `/essentials
 
 [VentureChat Spigot](https://www.spigotmc.org/resources/venturechat.771/)  
 
-[BitBucket](https://bitbucket.org/Aust1n46/venturechat/)  
+[GitHub](https://github.com/Aust1n46/VentureChat)
 
 [Wiki](https://www.spigotmc.org/wiki/venturechat-wiki/)


### PR DESCRIPTION
 ### VentureChat 
- Add note that it needs java 17 or later to work
- source code repo moved to github, updated the link

### GeyserMC
- Wiki has moved to a new address, this updates its link

### advanced anti cheat
- Moved documentation into 'View Legacy Documentation' dropdown as the plugin hasn't been updated for several years and doesn't work on current versions of Minecraft (see #204)

### Prism
- The Spigot link, Wiki link and GitHub repo has changed. This updates the links to those
- The config for the MySQL database in the latest versions seems to have changed slightly and this updates the page to reflect these.
- removed modrinth link as the downloads are not updated for more modern versions of minecraft