### PR TITLE
Fixed GTNH bot embed thumbnail path.

### DIFF
--- a/embeds.yml
+++ b/embeds.yml
@@ -800,7 +800,7 @@ gtnh:
   title: '📜 Bloom Docs - GTNH'
   description: >
     Check out our guide to installing Gregtech: New Horizons [here](https://docs.bloom.host/gtnh/).
-  thumbnail: 'https://raw.githubusercontent.com/Bloom-host/BloomDocs/master/static/plugins_and_modifications/GTNH_icon.png'
+  thumbnail: 'https://raw.githubusercontent.com/Bloom-host/BloomDocs/master/static/plugins_and_modifications/gtnh/GTNH_icon.png'
 
 plugins:
   aliases:


### PR DESCRIPTION
The Embed for the gtnh command contained typo which 404'd the thumbnail, this is now corrected.