### PR TITLE
Timings: Paper builds for 1.21 will disable timings by default

### DIFF
--- a/docs/running_a_server/timings.md
+++ b/docs/running_a_server/timings.md
@@ -24,6 +24,8 @@ keywords:
 The PaperMC team has decided to remove the Timings system and replace it with [Spark](https://docs.bloom.host/spark) in a future version. 
 Timings should be considered depricated and no longer be used.
 
+Paper 1.21 builds will have the timings system disabled by default.
+
 More information can be found [here](https://github.com/PaperMC/Paper/issues/8948)
 :::
 


### PR DESCRIPTION
PaperMC team has disabled the timings system for 1.21 builds by default, this seems like the next part of the plan to remove timings completely 