### PR TITLE
Add note that Spark is included in Paper 1.21, Add embed note that Timings is deprecated

### DIFF
--- a/docs/running_a_server/spark.md
+++ b/docs/running_a_server/spark.md
@@ -23,6 +23,8 @@ It does not require any configuration and is incredibly easy to install.
 ### Setup
 :::note
 You can ignore this step if you are running Purpur 1.19.1 or above.
+
+Paper 1.21+ includes Spark by default and you do not need to download Spark separately. 
 :::
 Download the latest build from [Spark](https://spark.lucko.me/download) and drop it into your plugins (or mod folder if you are running Forge/Fabric) folder. Turn on or restart the server, and you're done! If you need help installing plugins, check [How to install plugins](https://docs.bloom.host/installing-plugins).
 

--- a/embeds.yml
+++ b/embeds.yml
@@ -915,6 +915,10 @@ timings:
   aliases: [ 'timing' ]
   title: '📜 Bloom Docs - Timings'
   description: >
+    ⚠️ Timings has been deprecated by PaperMC team in 1.21 and will be removed in a future version.
+    The PaperMC team will be replacing timings with Spark (see `!spark`).
+    More information is available [here](https://github.com/PaperMC/Paper/discussions/10565).
+
     Check out our comprehensive guide on creating a timings report to
     debug TPS issues on your server [here](https://docs.bloom.host/timings/).
   thumbnail: 'https://raw.githubusercontent.com/Bloom-host/BloomDocs/master/static/discord/tY6IAF.png'

--- a/sidebars.js
+++ b/sidebars.js
@@ -76,7 +76,7 @@ module.exports = {
                 'running_a_server/java-version',
                 'running_a_server/datapacks',
                 'running_a_server/spark',
-                'running_a_server/timings',
+                'running_a_server/timings', // Deprecated, will be removed in a future version of Paper (https://github.com/PaperMC/Paper/discussions/10565)
                 'running_a_server/icon',
                 'running_a_server/motd',
                 'running_a_server/whitelist', // How to turn on whitelist for both Java and Bedrock


### PR DESCRIPTION
- Adds a note to the spark install notes that paper 1.21+ has spark built in and doesn't need to be downloaded separately
- Adds a message to the timings embed that papermc has deprecated timings and will be removed in a future version (replaced with spark) 