### PR TITLE
Fix broken links and slug inconsistencies

### DIFF
--- a/docs/VPS/starting-with-vps.md
+++ b/docs/VPS/starting-with-vps.md
@@ -67,5 +67,5 @@ After that, click on the "Open" button and the SSH connection will start, you wi
 ![img](/VPS/starting-with-vps/3.png)
 
 :::important
-Need to connect to your VPS via VNC? Check out our guide here: [How to connect to your VPS via VNC](vnc.md)
+Need to connect to your VPS via VNC? Check out our guide here: [How to connect to your VPS via VNC](vnc)
 :::

--- a/docs/extras/ab.md
+++ b/docs/extras/ab.md
@@ -34,7 +34,7 @@ Additionally, please make sure you are using Waterfall, Velocity or a Spigot-bas
 Here is how you can install the plugin:
 
 1. Ensure your server is using a supported port. Currently, this is `25565`, `25566` and `25567`.
-  If this isn't the case, please update your main port to one of the supported ones in the [Ports & Proxies tab](../using_the_panel/ports-and-proxies.md) 
+  If this isn't the case, please update your main port to one of the supported ones in the [Ports & Proxies tab](/ports-and-proxies)
 2. Open the [latest release on GitHub](https://github.com/Bloom-host/BloomAB/releases/latest) and download the `BloomAB-xxx.jar` file.  
   This JAR file will work for all 3 platforms.
 3. Open your server in the [DuckPanel](https://mc.bloom.host) and click the 'File Manager' tab.  
@@ -51,7 +51,7 @@ Here is how you can install the plugin:
 
 By default, you do not need to modify anything after the initial setup for this to work. Whenever a bot attack happens, the plugin will detect it and notify the DDoS protection.
 
-There are a few commands you can use in-game with the `bab.admin.manage` [permission](../plugins_and_modifications/multiplatform/luckperms.md) or in the console:
+There are a few commands you can use in-game with the `bab.admin.manage` [permission](/multiplatform/luckperms) or in the console:
 - `/bloomab force <seconds>`: Force trigger the protection for X seconds.
 - `/bloomab forcestop <seconds>`: Force disable the protection for X seconds.
 - `/bloomab set <maxjps|duration|location> <new value>`: Modify the `config.yml` and update the values live. 

--- a/docs/extras/ping-issues.md
+++ b/docs/extras/ping-issues.md
@@ -20,7 +20,7 @@ This guide will go over how to run an MTR, how to diagnose ping issues and poten
 ## How to run an MTR
 
 :::warning
-Please follow our [MTR guide](mtr.md).
+Please follow our [MTR guide](/mtr).
 :::
 
 ---

--- a/docs/games/palworld/update.md
+++ b/docs/games/palworld/update.md
@@ -11,7 +11,7 @@ Restarting the server.
 Server should auto update on restarts, if it doesn't follow Method 2
 
 # Method 2
-First, stop your server. Then, go to the [Backups](/using_the_panel/backups/guide.md) tab. 
+First, stop your server. Then, go to the [Backups](/backups) tab. 
 Make a backup just incase something goes wrong, after that go to Settings tab, click Reinstall. 
 
 

--- a/docs/games/rust/plugins.md
+++ b/docs/games/rust/plugins.md
@@ -46,7 +46,7 @@ first time after installing new plugins, but you will see the status show as 'Ru
 ![Server showing loaded](/games/rust/plugins/loaded.png)
 
 Lastly, you can verify that the plugin is installed by using the `plugins` command in-game as
-an [administrator](admin.md) or in the console.
+an [administrator](admin) or in the console.
 ![Command verifying successful installation](/games/rust/plugins/list.png)
 
 ---

--- a/docs/games/rust/worlds.md
+++ b/docs/games/rust/worlds.md
@@ -43,7 +43,7 @@ by [Caitthulu](https://codefling.com/caitthulu).
 
 Once you have your map, you will need a way to host it. There are several ways, such as:
 
-1. Using a [Caddy](/other-servers/caddy-server.md) server split
+1. Using a [Caddy](/other-servers/caddy-server) server split
 2. Using Dropbox's free tier
 3. Any other direct file hosting services
 

--- a/docs/games/terraria/banning.md
+++ b/docs/games/terraria/banning.md
@@ -49,7 +49,7 @@ Changes to the file are reflected instantly.
 
 ## TShock
 
-When using [TShock](tshock/overview.md), it's possible to ban based on the server-side user profiles instead of the
+When using [TShock](tshock/overview), it's possible to ban based on the server-side user profiles instead of the
 IP address.
 
 ### Banning

--- a/docs/games/terraria/tmodloader/mods.md
+++ b/docs/games/terraria/tmodloader/mods.md
@@ -8,7 +8,7 @@ note: This is referenced on the /terraria page on the main site
 
 :::caution HEADS UP!
 Mods are not part of the vanilla server software, so in order for this to work, you must
-install [tModLoader](overview.md).
+install [tModLoader](overview).
 :::
 
 Mods are a way for developers to add new items, bosses, mechanics and more into the game.

--- a/docs/games/terraria/tmodloader/overview.md
+++ b/docs/games/terraria/tmodloader/overview.md
@@ -25,7 +25,7 @@ through [Steam](https://store.steampowered.com/app/1281930/tModLoader/) on your 
 :::
 
 :::caution HEADS UP!
-If your server is already using Terraria, make sure to [create a backup](/using_the_panel/backups/guide.md) before following
+If your server is already using Terraria, make sure to [create a backup](/backups) before following
 the steps below.
 :::
 

--- a/docs/games/terraria/tshock/admin.md
+++ b/docs/games/terraria/tshock/admin.md
@@ -7,7 +7,7 @@ description: Learn how you can earn admin privileges on your TShock server!
 
 :::caution HEADS UP!
 Special commands and permissions are not part of the vanilla server software, so in order for this to work, you must
-install [TShock](overview.md).
+install [TShock](overview).
 :::
 
 Once the server loads, you should see a few lines about the `/setup` command:

--- a/docs/games/terraria/tshock/crossplay.md
+++ b/docs/games/terraria/tshock/crossplay.md
@@ -7,7 +7,7 @@ description: Learn how you can enable mobile <-> PC crossplay on your TShock ser
 
 :::caution HEADS UP!
 This is not possible with the vanilla server software, so in order for this to work, you must
-install [TShock](overview.md).
+install [TShock](overview).
 :::
 
 By default the game only allows either PC, or mobile players to connect to a server. To work around this limitation, you

--- a/docs/games/terraria/tshock/overview.md
+++ b/docs/games/terraria/tshock/overview.md
@@ -20,10 +20,10 @@ and [Discord](https://discord.gg/Cav9nYX)!
 ## Usage
 
 :::caution HEADS UP!
-If your server is already using the regular Terraria, install, make sure to [create a backup](/using_the_panel/backups/guide.md) before following the
+If your server is already using the regular Terraria, install, make sure to [create a backup](/backups) before following the
 steps below.
 
-If your server is using [TModLoader](/games/terraria/tmodloader/overview.md) with mods that modify the world, it may not
+If your server is using [TModLoader](/games/terraria/tmodloader/overview) with mods that modify the world, it may not
 be possible to use TShock with your existing world.
 :::
 

--- a/docs/games/terraria/tshock/plugins.md
+++ b/docs/games/terraria/tshock/plugins.md
@@ -8,7 +8,7 @@ note: This is referenced on the /terraria page on the main site
 
 :::caution HEADS UP!
 Plugins are not part of the vanilla server software, so in order for this to work, you must
-install [TShock](overview.md).
+install [TShock](overview).
 :::
 
 First, find some plugins you would like to install. A safe source is

--- a/docs/games/terraria/tshock/whitelisting.md
+++ b/docs/games/terraria/tshock/whitelisting.md
@@ -6,12 +6,12 @@ description: Learn how to set up and manage a whitelist on your Terraria server!
 ---
 
 :::info HEADS UP
-The game does not provide a whitelisting functionality by default, so we will have to use [TShock](overview.md), a
+The game does not provide a whitelisting functionality by default, so we will have to use [TShock](overview), a
 third party server software.
 
 As an alternative for the vanilla server, you can use [server passwords](/games/terraria/password).
 
-If you haven't already, make sure to install is using [the steps here](overview.md)!
+If you haven't already, make sure to install is using [the steps here](overview)!
 :::
 
 ## Toggling Whitelist

--- a/docs/games/terraria/worlds.md
+++ b/docs/games/terraria/worlds.md
@@ -20,7 +20,7 @@ directory with the `.wld` extension.
 You can find your single player worlds by pressing Windows Key + R and entering: `Documents/My Games/Terraria/Worlds`
 
 Once you have found the file, you can use the panel's [File Manager](/file-manager-controls)
-or [SFTP](/sftp.md) to access your server's files.
+or [SFTP](/sftp) to access your server's files.
 
 Here, find for the `saves/Worlds/` directory and upload your `.wld` into it.
 

--- a/docs/plugins_and_modifications/fabric_mods/performance-mods.md
+++ b/docs/plugins_and_modifications/fabric_mods/performance-mods.md
@@ -2,7 +2,7 @@
 id: performance-mods
 title: Performance Mods
 header: Performance Mods for Fabric
-slug: /f_performance_mods
+slug: /fabric-performance-mods
 hide_table_of_contents: true
 sidebar_label: Performance Mods
 description: A list of mods that will help combat lag on fabric servers.
@@ -15,7 +15,7 @@ keywords:
 ---
 
 :::note
-Make sure to also check out the [Server Optimization Guide](../../running_a_server/optimization.md)
+Make sure to also check out the [Server Optimization Guide](/optimization)
 :::
 
 ## How to install these mods

--- a/docs/plugins_and_modifications/installing-plugins.md
+++ b/docs/plugins_and_modifications/installing-plugins.md
@@ -7,13 +7,13 @@ sidebar_label: Installing Spigot Plugins
 ---
 
 :::important
-This guide is for Bukkit/Spigot/Paper servers. If you are looking for instructions on how to install plugins on a BungeeCord/Waterfall or Velocity proxy, please see [this guide](proxy-plugins.md)
+This guide is for Bukkit/Spigot/Paper servers. If you are looking for instructions on how to install plugins on a BungeeCord/Waterfall or Velocity proxy, please see [this guide](/installing-proxy-plugins)
 :::
 
 ### The Basics
 > #### Requirements
 > 
-> In order to run plugins on your server, you have to be using a fork of Bukkit. (such as Spigot, Paper, Pupur, Pufferfish, etc. See our [guide on server jars](/jars) for more information.) If you wish to make client-side modifications (as well), see our guide on [installing server mods](mods-install.md)!
+> In order to run plugins on your server, you have to be using a fork of Bukkit. (such as Spigot, Paper, Pupur, Pufferfish, etc. See our [guide on server jars](/jars) for more information.) If you wish to make client-side modifications (as well), see our guide on [installing server mods](/mods-install)!
 
 > #### What are plugins?
 >
@@ -30,7 +30,7 @@ Make sure you trust the source of your plugin. Plugins have high-level access to
 ### Installing Plugins
 
 1. You'll first need to find the plugin you wish to install. Downloads can be found on a variety of sites. Common places are [spigotmc.org](https://spigotmc.org/resources), [bukkit.org](https://dev.bukkit.org), [Modrinth](https://modrinth.com/plugins) or [Hangar](https://hangar.papermc.io/) websites.
-2. In any case, save the plugin to your local machine. Plugins can either be uploaded via the [web panel](https://mc.bloom.host) or through [SFTP](../using_the_panel/sftp.md). If you're uploading in bulk, go with the latter.
+2. In any case, save the plugin to your local machine. Plugins can either be uploaded via the [web panel](https://mc.bloom.host) or through [SFTP](/sftp). If you're uploading in bulk, go with the latter.
 3. In your server's root directory, locate the `plugins` folder, if it's not there then create a new directory named `plugins`. Navigate into this folder, and upload your plugin's file there!
 4. Most plugins will require you to restart your server before they take effect.
 

--- a/docs/plugins_and_modifications/mods-install.md
+++ b/docs/plugins_and_modifications/mods-install.md
@@ -21,7 +21,7 @@ You'll first need to find the mod that you wish to install. Downloads can be fou
 Make sure you are downloading the correct version of your mods. Forge and Fabric mods are most likely not cross compatible with each other unless stated so otherwise by the developer of those mods.
 :::
 
-You have two choices: save the mod to your local machine and then upload it to the panel or copy the link to the mod download and use our Download from URL feature which can be found on the File Manager. Mods can either be uploaded via the [web panel](https://mc.bloom.host) or through [SFTP](/using_the_panel/sftp.md). If you're uploading in bulk, go with the latter. 
+You have two choices: save the mod to your local machine and then upload it to the panel or copy the link to the mod download and use our Download from URL feature which can be found on the File Manager. Mods can either be uploaded via the [web panel](https://mc.bloom.host) or through [SFTP](/sftp). If you're uploading in bulk, go with the latter.
 
 In your server's root directory, locate the `/mods` folder, if it's not there then create a new directory named `/mods`. Navigate into this folder, and upload your mods' files there! The vast majority of mods require you to restart your server to take effect.
 

--- a/docs/plugins_and_modifications/plugins/essentialsx.md
+++ b/docs/plugins_and_modifications/plugins/essentialsx.md
@@ -28,15 +28,15 @@ This guide does not cover all of EssentialsX's features, please check the [Essen
 
 ## What does this plugin do?
 
-This is a plugin that offers basic commands and features such as a mail system, request tp system,  economy systems (sign shops, command costs), player nicknames and moderation tools if you don't want to install plugins such as [LiteBans](../multiplatform/litebans.md) or [AdvancedBan](../multiplatform/advancedban.md).
+This is a plugin that offers basic commands and features such as a mail system, request tp system,  economy systems (sign shops, command costs), player nicknames and moderation tools if you don't want to install plugins such as [LiteBans](/multiplatform/litebans) or [AdvancedBan](/multiplatform/advancedban).
 
-This plugin also hooks into [Vault](vault.md) to provide an economy service that other economy plugins on your server can use. It can also get group names from your permission plugin.
+This plugin also hooks into [Vault](/plugins/vault) to provide an economy service that other economy plugins on your server can use. It can also get group names from your permission plugin.
 
 ## Install
 
 You can either download stable builds from its [Spigot Resource page](https://www.spigotmc.org/resources/essentialsx.9089/), its [Modrinth Resource page](https://modrinth.com/mod/essentialsx) or you can download dev, experimental builds directly from [its website.](https://essentialsx.net/downloads.html)
 
-Next, place the EssentialsX jar file into the `plugins` folder in your server. If you need help with installing plugins, [click here for a guide.](../installing-plugins.md)
+Next, place the EssentialsX jar file into the `plugins` folder in your server. If you need help with installing plugins, [click here for a guide.](/installing-plugins)
 
 ## Usage
 

--- a/docs/plugins_and_modifications/plugins/vault.md
+++ b/docs/plugins_and_modifications/plugins/vault.md
@@ -23,13 +23,13 @@ Vault provides a common API to give plugins access to chat, permission and econo
 ## Installation Instructions
 Download Vault from its [Spigot Resource page](https://www.spigotmc.org/resources/vault.34315/) or its [BukkitDev page](https://dev.bukkit.org/projects/vault) or directly from its [GitHub repo](https://github.com/MilkBowl/Vault/releases).
 
-Next, install the plugin into the `plugins` folder in your server. Need help? Check out [this guide](../installing-plugins.md).
+Next, install the plugin into the `plugins` folder in your server. Need help? Check out [this guide](/installing-plugins).
 
 ## Usage instructions
 
-Vault works out of the box without configuration in most cases. Plugins that hook into Vault (e.g. [LuckPerms](../multiplatform/luckperms.md)) will automatically find Vault and connect to it and provides a hook for plugins to work with it.
+Vault works out of the box without configuration in most cases. Plugins that hook into Vault (e.g. [LuckPerms](/multiplatform/luckperms)) will automatically find Vault and connect to it and provides a hook for plugins to work with it.
 
-Other plugins, such as [DiscordSRV](discordsrv.md) can use the information provided by Vault (e.g. DiscordSRV can get the group names from your permissions plugin)
+Other plugins, such as [DiscordSRV](/plugins/discordsrv) can use the information provided by Vault (e.g. DiscordSRV can get the group names from your permissions plugin)
 
 ### Commands
 

--- a/docs/plugins_and_modifications/plugins/worldguard.md
+++ b/docs/plugins_and_modifications/plugins/worldguard.md
@@ -15,7 +15,7 @@ description: An in-game world guard plugin to protect blocks and regions.
 ---
 
 :::important
-To use WorldGuard, you need to install [WorldEdit](../multiplatform/worldedit.md) onto your server.
+To use WorldGuard, you need to install [WorldEdit](/multiplatform/worldedit) onto your server.
 :::
 
 ### What does the plugin do?

--- a/docs/plugins_and_modifications/proxy-plugins.md
+++ b/docs/plugins_and_modifications/proxy-plugins.md
@@ -7,7 +7,7 @@ sidebar_label: Proxy (BungeeCord/Velocity) Plugins
 ---
 
 :::important
-This guide is for BungeeCord/Velocity proxies. If you are looking for instructions on how to install plugins on a Bukkit/Spigot/Paper server, please see [this guide](installing-plugins.md)
+This guide is for BungeeCord/Velocity proxies. If you are looking for instructions on how to install plugins on a Bukkit/Spigot/Paper server, please see [this guide](/installing-plugins)
 :::
 
 :::caution Waterfall is End of Life
@@ -40,7 +40,7 @@ Make sure you trust the source of your plugin. Plugins have high-level access to
 ### Installing Plugins
 
 1. You'll first need to find the plugin you wish to install. Downloads can be found on a variety of sites. Common places are [spigotmc.org](https://spigotmc.org/resources) (look at the BungeeCord or Universal sections), [Hangar](https://hangar.papermc.io/) (under platforms select which proxy software you are using) or [Modrinth](https://modrinth.com/plugins) (under proxies filter select the proxy software you are using).
-2. In any case, save the plugin to your local machine. Plugins can either be uploaded via the [web panel](https://mc.bloom.host) or through [SFTP](../using_the_panel/sftp.md). If you're uploading in bulk, go with the latter.
+2. In any case, save the plugin to your local machine. Plugins can either be uploaded via the [web panel](https://mc.bloom.host) or through [SFTP](/sftp). If you're uploading in bulk, go with the latter.
 3. In your server's root directory, locate the `plugins` folder, if it's not there then create a new directory named `plugins`. Navigate into this folder, and upload your plugin's file there!
 4. Most plugins will require you to restart your server before they take effect.
 

--- a/docs/running_a_server/datapacks.md
+++ b/docs/running_a_server/datapacks.md
@@ -52,7 +52,7 @@ While datapacks are built into the game, they can still have a large impact on s
 Certain creators such as [VanillaTweaks](https://vanillatweaks.net/picker/datapacks/) are mindful of this, but it's
 important to note that this is not always the case.
 
-If you notice lag spikes or tick loss, make sure to run a [Spark report](spark.md).
+If you notice lag spikes or tick loss, make sure to run a [Spark report](/spark).
 If you find `CustomFunction` calls taking up a large chunk of the total server tick, it's possible one of the datapacks
 is running calculation expensive commands.
 

--- a/docs/running_a_server/domain.md
+++ b/docs/running_a_server/domain.md
@@ -50,7 +50,7 @@ If you have a split server or Essentials Plans server and it doesn't have a 2556
 :::note
 SRV records are only supported on Java clients, Bedrock clients will be unable to resolve this record.
 
-If you wish to have multiple servers with clean domains on a network, [it's recommended to setup a network proxy](../running_a_server/velocity.md).
+If you wish to have multiple servers with clean domains on a network, [it's recommended to setup a network proxy](/velocity).
 :::
 
 :::warning

--- a/docs/running_a_server/exploitfix.md
+++ b/docs/running_a_server/exploitfix.md
@@ -166,4 +166,4 @@ You should be able to download one of the jars above (make sure you download a b
 
 As per PaperMC team: To test if the patch is working, run `say ${date:YYYY}` in console, it should output the same command and not `2021`. If it outputs `2021` you have not fixed the issue properly.
 
-If you need help updating your server please refer to our [Updating](updating.md) guide and #support-chat channel.
+If you need help updating your server please refer to our [Updating](/updating) guide and #support-chat channel.

--- a/docs/running_a_server/mcaselector.md
+++ b/docs/running_a_server/mcaselector.md
@@ -14,7 +14,7 @@ To avoid having to download and re-upload your world each time, Bloom has a pre-
 ## Preparation
 
 :::danger
-**WARNING**: Before doing anything else, please head over to the **[backups](/using_the_panel/backups/guide.md)** guide to create a full backup of your server.
+**WARNING**: Before doing anything else, please head over to the **[backups](/backups)** guide to create a full backup of your server.
 :::
 
 1. In the DuckPanel open your server and, select the 'Settings' tab.

--- a/docs/running_a_server/optimization.md
+++ b/docs/running_a_server/optimization.md
@@ -38,7 +38,7 @@ The bukkit platform allows you to use plugins, and fabric allows you to run mods
 
 For the Bukkit platform you have many options for a server jar, the most stable of which is [Paper](https://papermc.io). Paper includes many performance improvements, bug fixes and configuration options. If you want additional configuration options along with getting the latest stable patches early [Purpur](https://purpurmc.org/downloads) might be for you.
 
-For Fabric check our [Fabric Setup](/jars) page. Fabric by itself doesn't change the game at all, to get performance improvements check out our [Fabric Performance Mods](../plugins_and_modifications/fabric_mods/performance-mods.md) page.
+For Fabric check our [Fabric Setup](/jars) page. Fabric by itself doesn't change the game at all, to get performance improvements check out our [Fabric Performance Mods](/fabric-performance-mods) page.
 
 ---
 ## Guides to optimize your server

--- a/docs/running_a_server/updating.md
+++ b/docs/running_a_server/updating.md
@@ -1,7 +1,7 @@
 ---
 id: updating
 title: How to update or change version
-sslug: /updating
+slug: /updating
 hide_table_of_contents: true
 sidebar_label: Updating or changing versions
 ---
@@ -33,6 +33,6 @@ After you have followed the steps above, you can periodically check the **Settin
 ### Updating the server manually
 - Make sure that your server is backed up completely.
 - [Create full backup](/backups) of your server. (As an additional step, we would suggest testing this backup on a local or a split test server)
-- Remove your current server jar through [SFTP](../sftp.md) or the [File Manager](../file-manager-controls).
+- Remove your current server jar through [SFTP](/sftp) or the [File Manager](/file-manager-controls).
 - Download the new version of your server software. If you are unsure which one to use, check out our guide on server jars [here](/jars).
 - Upload it using SFTP or the File Manager and make sure to define the full name (such as `paper-1.18-023` in the 'Startup' tab on the panel)

--- a/docs/running_a_server/velocity.md
+++ b/docs/running_a_server/velocity.md
@@ -64,7 +64,7 @@ The first section of the config file you need to edit is the `[servers]` section
 
 :::note
 
-Before you setup this section, you're going to want to make sure all your backend servers are internal. You can make your backend servers internal by going to the Ports and Proxies tab under the specific server and clicking "Make Internal", that will remove all public access to your backend servers which is what we want. When a server is internal they are only accessible via other servers in the same split. If you would like to read more information on our internal servers please see [here](internal-servers.md).
+Before you setup this section, you're going to want to make sure all your backend servers are internal. You can make your backend servers internal by going to the Ports and Proxies tab under the specific server and clicking "Make Internal", that will remove all public access to your backend servers which is what we want. When a server is internal they are only accessible via other servers in the same split. If you would like to read more information on our internal servers please see [here](/internal-servers).
 
 :::
 
@@ -158,7 +158,7 @@ This section also applies to forks based upon Paper such as Purpur or Pufferfish
 
 If you cannot use modern forwarding (for example, your server jar doesn't support Velocity modern forwarding), you might be able to use BungeeGuard instead.
 
-To set this up, see the guide [on how to set up BungeeGuard](waterfall.md#setting-up-bungeeguard).
+To set this up, see the guide [on how to set up BungeeGuard](/waterfall#setting-up-bungeeguard).
 
 ## Additional configuation options for velocity.toml
 

--- a/docs/running_a_server/waterfall.md
+++ b/docs/running_a_server/waterfall.md
@@ -18,7 +18,7 @@ keywords:
 :::warning END OF LIFE SOFTWARE
 **As of March 26th, 2024, Waterfall has been marked as EOL by the Paper team**. More details are available on [the PaperMC forums](https://forums.papermc.io/threads/announcing-the-end-of-life-of-waterfall.1088/).
 
-### **Please migrate to [Velocity](velocity.md) as soon as possible!**
+### **Please migrate to [Velocity](/velocity) as soon as possible!**
 
 :::
 

--- a/docs/running_a_server/world-reset.md
+++ b/docs/running_a_server/world-reset.md
@@ -14,7 +14,7 @@ keywords:
   - Bloom.host
 ---
 
-You'll need a way to access your server files. This tutorial references the [web panel](https://mc.bloom.host), but you can also use [SFTP](/using_the_panel/sftp.md). **Shutdown your server before proceeding!**
+You'll need a way to access your server files. This tutorial references the [web panel](https://mc.bloom.host), but you can also use [SFTP](/sftp). **Shutdown your server before proceeding!**
 
 Either way, go to the root directory of your server. On the web panel, this can be done by selecting your server, dropping down the "File Management" menu, then selecting "File Explorer". When you connect to your server via SFTP, you should be already at your root directory.
 
@@ -23,7 +23,7 @@ The following steps will __completely erase__ your worlds.
 
 If you wish to have multiple worlds on your server at once, add a prefix to the end of each world (such as `_old`), OR use a plugin such as [Multiverse](https://dev.bukkit.org/projects/multiverse-core).
 
-We recommend you take a backup before deleting any worlds in your server. Follow this [guide](/using_the_panel/backups/guide.md) to learn how to make and schedule backups.
+We recommend you take a backup before deleting any worlds in your server. Follow this [guide](/backups) to learn how to make and schedule backups.
 :::
 
 You now have to locate your world files, on *most* Minecraft servers these folders will be `world`, `world_nether`, and `world_the_end` - if not, check your `level-name` in `server.properties`.

--- a/docs/running_a_server/worlds.md
+++ b/docs/running_a_server/worlds.md
@@ -8,7 +8,7 @@ description: Learn how you can upload, export and manage your Minecraft worlds.
 ---
 
 :::note
-If you'd like to import ALL your files from another hosting company, please follow our [Server Importer](../server-importer) guide instead!
+If you'd like to import ALL your files from another hosting company, please follow our [Server Importer](/server-importer) guide instead!
 :::
 
 # Importing Worlds
@@ -27,7 +27,7 @@ Then, select all the files within the open directory and right click. Select 'Se
 ![img](/running_a_server/worlds/3.png)
 You may get a warning about empty folders being skipped but that is okay!
 
-Next, follow [our guide on connecting to your server with an SFTP client](/sftp.md). In most cases, your world files will be fairly large, so it's best to use a dedicated file transfer protocol, instead of the built-in web file manager.
+Next, follow [our guide on connecting to your server with an SFTP client](/sftp). In most cases, your world files will be fairly large, so it's best to use a dedicated file transfer protocol, instead of the built-in web file manager.
 Once connected via SFTP, right click in SFTP and create a new folder, such as `my-world` and open it.
 ![img](/running_a_server/worlds/4.png)
 
@@ -44,7 +44,7 @@ After unzipping, here is how it should generally look.
 Now, if you'd like this to be your main world, open the `server.properties` file in the main directory of your server and ensure the `level-name=` setting matches with the folder that you created before:
 ![img](/running_a_server/worlds/8.png)
 
-Alternatively, if you'd like to use a plugin or mod such as [Multiverse-Core](/plugins_and_modifications/plugins/multiverse.md), you can import it using the folder's name.
+Alternatively, if you'd like to use a plugin or mod such as [Multiverse-Core](/plugins/multiverse), you can import it using the folder's name.
 In our example, for Multiverse-Core, you'd do `/mvimport my-world NORMAL`
 
 That's it! Make sure to restart your server to apply the changes.
@@ -80,7 +80,7 @@ Scroll down to the very bottom of the main page and press 'Export World':
 Select your desktop, or another easy to access location:
 ![img](/running_a_server/worlds/14.png)
 
-Next, follow [our guide on connecting to your server with an SFTP client](/sftp.md). In most cases, your world files will be fairly large, so it's best to use a dedicated file transfer protocol, instead of the built-in web file manager.
+Next, follow [our guide on connecting to your server with an SFTP client](/sftp). In most cases, your world files will be fairly large, so it's best to use a dedicated file transfer protocol, instead of the built-in web file manager.
 Once connected via SFTP, open the `worlds` directory and create a new folder, such as `my-world` and open it.
 ![img](/running_a_server/worlds/15.png)
 
@@ -103,7 +103,7 @@ That's it! Make sure to restart your server to apply the changes.
 ---
 
 # Resetting Worlds
-You can find our full guide on resetting your world [here](world-reset.md)!
+You can find our full guide on resetting your world [here](/world-reset)!
 
 <!--
 // Todo:

--- a/docs/using_the_panel/file-manager-controls.mdx
+++ b/docs/using_the_panel/file-manager-controls.mdx
@@ -8,7 +8,7 @@ sidebar_label: File Manager Controls
 
 ### SFTP
 
-If you would prefer to use SFTP to manage your files, please see our [guide on SFTP](sftp.md).
+If you would prefer to use SFTP to manage your files, please see our [guide on SFTP](/sftp).
 
 ---
 

--- a/docs/using_the_panel/ports-and-proxies.md
+++ b/docs/using_the_panel/ports-and-proxies.md
@@ -9,7 +9,7 @@ description: This guide will help you to create a reverse proxy.
 
 ---
 :::warning
-## Reverse proxies can only be used for *web connections* (eg. HTTPS). If you want to join your minecraft server using your domain, check [this page](../running_a_server/domain.md)
+## Reverse proxies can only be used for *web connections* (eg. HTTPS). If you want to join your minecraft server using your domain, check [this page](/domain)
 :::
 :::note
 For this guide, you must have access to a domain and the ability to alter that domain's DNS settings. In this guide, we assume you have a domain with Cloudflare, but most registrars will work.


### PR DESCRIPTION
## Changes

- Removed `.md` extensions from all internal doc links across 34 files
- Fixed broken/mismatched internal links to use correct slugs
- Fixed typo in `updating.md` (`sslug` → `slug`)
- Changed fabric performance mods slug from `/f_performance_mods` to `/fabric-performance-mods`
- Updated all references to match corrected slugs

## Summary

All internal documentation links now correctly reference their target pages using the proper slug format without `.md` extensions, ensuring they resolve correctly in Docusaurus.