### PR TITLE
Add fork-safe Cloudflare Pages preview deployments

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,45 @@
+name: Build Preview Deployment
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+# This workflow runs untrusted PR code (including from forks), so it gets no
+# secrets and read-only permissions. It only produces a build artifact, which
+# the privileged "Upload Preview Deployment" workflow then deploys.
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    name: Build Preview Site and Upload Build Artifact
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-build
+          path: build
+          retention-days: 1

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,42 @@
+name: Upload Preview Deployment
+
+on:
+  workflow_run:
+    workflows:
+      - Build Preview Deployment
+    types:
+      - completed
+
+# workflow_run always runs from the default branch, so this file (and the
+# secrets it uses) can never be modified by a PR. It only ever consumes the
+# build artifact produced by the unprivileged build workflow.
+permissions:
+  actions: read
+  contents: read
+  deployments: write
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Deploy Preview to Cloudflare Pages
+    steps:
+      - name: Download build artifact
+        id: preview-build-artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-build
+          path: build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Deploy to Cloudflare Pages
+        uses: AdrianGonz97/refined-cf-pages-action@45ea15c1c69a7bce8ffbb79ba114daa2b52f0cff # v1.3.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: bloomdocs
+          deploymentName: Preview
+          directory: ${{ steps.preview-build-artifact.outputs.download-path }}


### PR DESCRIPTION
## Problem

Cloudflare Pages' Git integration doesn't build preview deployments for pull requests opened from forks — and forks are how essentially every community docs contribution arrives. Today those PRs get reviewed without anyone being able to see the rendered page.

## What this does

Adds the fork-safe two-workflow pattern from [refined-cf-pages-action](https://github.com/AdrianGonz97/refined-cf-pages-action), so every PR (fork or not) gets a preview URL and a GitHub deployment status attached to the PR.

**`.github/workflows/preview-build.yml`** — runs on `pull_request`. This is where untrusted PR code executes, so it has `permissions: contents: read` and no secrets at all. It runs `npm ci && npm run build` on Node 24.18.0 (matching the Cloudflare build settings) and uploads `build/` as an artifact.

**`.github/workflows/preview-deploy.yml`** — runs on `workflow_run` when the build finishes successfully. `workflow_run` jobs always execute the workflow file from the default branch, so this file can't be modified by a PR. It downloads the artifact and uploads it to the `bloomdocs` Pages project as a preview deployment.

The split is the security property: the job holding the Cloudflare API token never checks out or runs PR code.

## Setup required before this works

Two repository secrets need to be added under Settings → Secrets and variables → Actions:

- `CLOUDFLARE_API_TOKEN` — an API token with the **Cloudflare Pages: Edit** permission
- `CLOUDFLARE_ACCOUNT_ID`

Until those exist the deploy job will fail; the build job is unaffected.

## Notes

- Production deploys of `master` are unchanged — still handled by the existing Cloudflare Git integration. This only adds previews.
- `refined-cf-pages-action` is pinned to the commit SHA for `v1.3.0` rather than the floating `v1` tag, since that job has access to the Cloudflare token.
- Build artifacts have a 1-day retention since they're only needed for the handoff between the two workflows.
- Verified `npm ci && npm run build` succeeds locally and emits to `build/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)